### PR TITLE
fix: depth is not enough to fetch the required inference hash

### DIFF
--- a/closed/NVIDIA/Makefile.build
+++ b/closed/NVIDIA/Makefile.build
@@ -187,7 +187,7 @@ endif
 clone_loadgen:
 	@if [ ! -d $(LOADGEN_INCLUDE_DIR) ]; then \
 		echo "Cloning Official MLPerf Inference (For Loadgen Files)" \
-			&& git clone $(INFERENCE_URL) $(INFERENCE_DIR) --depth 5; \
+			&& git clone $(INFERENCE_URL) $(INFERENCE_DIR); \
 	fi
 	@echo "Updating Loadgen" \
 		&& cd $(INFERENCE_DIR) \


### PR DESCRIPTION
The Makefile needs to checkout the hash f7df3acb6880b6b3a92cd5a444d173137aa5d8ca which is further than 5 levels down.

Remove the depth to remain future proof.